### PR TITLE
fix(pkg): exclude lodash on rollup config

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,12 @@
   "scripts": {
     "prepare": "husky install",
     "build": "rollup -c",
+    "rebuild": "rimraf dist && yarn build",
     "dev": "yarn build --watch",
     "test": "jest"
+  },
+  "dependencies": {
+    "type-fest": "^3.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.0.3",
@@ -46,7 +50,6 @@
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.27.1",
     "ts-jest": "^29.0.3",
-    "type-fest": "^3.0.0",
     "typescript": "^4.5.2"
   },
   "lint-staged": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,6 +3,16 @@ import dts from "rollup-plugin-dts";
 import { optimizeLodashImports } from "@optimize-lodash/rollup-plugin";
 import { terser } from "rollup-plugin-terser";
 
+const lodashPackage = [
+  "lodash/transform.js",
+  "lodash/isArray.js",
+  "lodash/camelCase.js",
+  "lodash/isObject.js",
+  "lodash/kebabCase.js",
+  "lodash/snakeCase.js",
+  "lodash/upperCase.js",
+];
+
 export default [
   {
     input: ["src/main.ts"],
@@ -24,11 +34,11 @@ export default [
     ],
 
     preserveModules: true,
-    external: [],
+    external: ["lodash", ...lodashPackage],
   },
   {
     input: ["src/main.ts"],
-    output: [{ file: "dist/index.d.ts", format: "cjs" }],
+    output: [{ file: "dist/index.d.ts", format: "es" }],
     plugins: [
       dts({
         compilerOptions: {


### PR DESCRIPTION
Fix :
Exclude Lodash package into self node_modules
Release to v1.0.5

Bug :
![image](https://user-images.githubusercontent.com/77242429/196911726-34bc2d3a-aea5-4eb1-a119-57443e29a957.png)
